### PR TITLE
Fix spec.source to point to our repo

### DIFF
--- a/SwiftCollections.podspec
+++ b/SwiftCollections.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |spec|
   spec.swift_version = '5.5'
 
   spec.source = { 
-    :git => "https://github.com/apple/swift-collections.git",
+    :git => "https://github.com/WW-Digital/swift-collections.git",
     :tag => "#{spec.version}" 
   }
 


### PR DESCRIPTION
- This should fix the following error when pinning to a tag from ios-wwmobile:
[!] Unable to find a specification for 'SwiftCollections'.